### PR TITLE
feat: Implement volume control and standardize audio levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A self-hosted Discord music bot that plays audio from YouTube. Manage playback w
 *   **`!skip`**: Skips the currently playing song and plays the next song in the queue (if any).
 *   **`!queue` (`!q`)**: Displays the list of songs currently in the queue, including the song that is now playing.
 *   **`!nowplaying` (`!np`)**: Shows detailed information about the song that is currently playing.
+*   **`!volume [level]`**: Adjusts the playback volume (0-200%). If no level is provided, displays the current volume. Example: `!volume 75`
 
 ## Setup Instructions
 


### PR DESCRIPTION
This commit introduces volume control functionality and aims to provide more consistent audio output levels.

Changes:
- All audio playback (direct and queued) now uses `discord.PCMVolumeTransformer` wrapped around the `discord.FFmpegPCMAudio` source. This should help in standardizing the default playback volume and is essential for dynamic volume adjustments.
- Added `!volume [level]` command:
    - You can set the volume with `!volume <level>`, where level is 0-200.
    - If no level is provided (`!volume`), I will display the current volume.
    - Includes input validation and feedback messages for you.
- Stored `PCMVolumeTransformer` instances are managed per guild to allow for volume changes.
- Updated `README.md` to include the `!volume` command.

This addresses feedback regarding my audio being too quiet by default and adds a feature you requested for volume adjustment.